### PR TITLE
Yarn requirement

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -5,7 +5,14 @@ const { promisify } = require("util");
 const download = promisify(require("download-git-repo"));
 const axios = require("axios");
 const difftool = require("diff");
+const path = require("path");
 require("dotenv").config({ path: __dirname + "/.env.migration" });
+
+/**
+ * Get path to yarn module
+ */
+module.exports.yarn = path.normalize(__dirname + "/node_modules/yarn");
+
 /**
  * Write log to console with magenta color.
  * @param {string} content the log content

--- a/lib/new.js
+++ b/lib/new.js
@@ -1,6 +1,6 @@
 const { promisify } = require("util");
 const figlet = promisify(require("figlet"));
-const { log, spawn_log, clone } = require("../helper");
+const { log, spawn_log, clone, yarn } = require("../helper");
 const version = require("../zendro_dependencies.json");
 const fs = require("fs-extra");
 const path = require("path");
@@ -75,7 +75,6 @@ module.exports = async (name, options) => {
     path.normalize(process.cwd() + `/${name}/graphiql-auth/.env.production`)
   );
 
-
   if (!dockerize) {
     log("install graphql-server packages \n");
     let log_gqs = fs.openSync(
@@ -93,7 +92,7 @@ module.exports = async (name, options) => {
       path.normalize(process.cwd() + `/${name}/logs/single-page-app.log`),
       "w"
     );
-    await spawn_log(false, "npm", ["exec", "--", "yarn", "install"], {
+    await spawn_log(false, "npm", ["exec", "--", yarn, "install"], {
       detached: true,
       stdio: ["ignore", log_spa, log_spa],
       cwd: path.normalize(process.cwd() + `/${name}/single-page-app`),
@@ -104,7 +103,7 @@ module.exports = async (name, options) => {
       path.normalize(process.cwd() + `/${name}/logs/graphiql.log`),
       "w"
     );
-    await spawn_log(false, "npm", ["exec", "--", "yarn", "install"], {
+    await spawn_log(false, "npm", ["exec", "--", yarn, "install"], {
       detached: true,
       stdio: ["ignore", log_giql, log_giql],
       cwd: path.normalize(process.cwd() + `/${name}/graphiql-auth`),

--- a/lib/new.js
+++ b/lib/new.js
@@ -75,40 +75,41 @@ module.exports = async (name, options) => {
     path.normalize(process.cwd() + `/${name}/graphiql-auth/.env.production`)
   );
 
-  log("install graphql-server packages \n");
-  let log_gqs = fs.openSync(
-    path.normalize(process.cwd() + `/${name}/logs/graphql-server.log`),
-    "w"
-  );
-  await spawn_log(false, "npm", ["install"], {
-    detached: true,
-    stdio: ["ignore", log_gqs, log_gqs],
-    cwd: path.normalize(process.cwd() + `/${name}/graphql-server`),
-  });
-
-  log("install single-page-app packages \n");
-  let log_spa = fs.openSync(
-    path.normalize(process.cwd() + `/${name}/logs/single-page-app.log`),
-    "w"
-  );
-  await spawn_log(false, "yarn", ["install"], {
-    detached: true,
-    stdio: ["ignore", log_spa, log_spa],
-    cwd: path.normalize(process.cwd() + `/${name}/single-page-app`),
-  });
-
-  log("install graphiQL packages \n");
-  let log_giql = fs.openSync(
-    path.normalize(process.cwd() + `/${name}/logs/graphiql.log`),
-    "w"
-  );
-  await spawn_log(false, "yarn", ["install"], {
-    detached: true,
-    stdio: ["ignore", log_giql, log_giql],
-    cwd: path.normalize(process.cwd() + `/${name}/graphiql-auth`),
-  });
 
   if (!dockerize) {
+    log("install graphql-server packages \n");
+    let log_gqs = fs.openSync(
+      path.normalize(process.cwd() + `/${name}/logs/graphql-server.log`),
+      "w"
+    );
+    await spawn_log(false, "npm", ["install"], {
+      detached: true,
+      stdio: ["ignore", log_gqs, log_gqs],
+      cwd: path.normalize(process.cwd() + `/${name}/graphql-server`),
+    });
+
+    log("install single-page-app packages \n");
+    let log_spa = fs.openSync(
+      path.normalize(process.cwd() + `/${name}/logs/single-page-app.log`),
+      "w"
+    );
+    await spawn_log(false, "npm", ["exec", "--", "yarn", "install"], {
+      detached: true,
+      stdio: ["ignore", log_spa, log_spa],
+      cwd: path.normalize(process.cwd() + `/${name}/single-page-app`),
+    });
+
+    log("install graphiQL packages \n");
+    let log_giql = fs.openSync(
+      path.normalize(process.cwd() + `/${name}/logs/graphiql.log`),
+      "w"
+    );
+    await spawn_log(false, "npm", ["exec", "--", "yarn", "install"], {
+      detached: true,
+      stdio: ["ignore", log_giql, log_giql],
+      cwd: path.normalize(process.cwd() + `/${name}/graphiql-auth`),
+    });
+
     // remove docker files by default
     log("Remove Docker files.");
     await fs.remove(path.normalize(`${name}/contexts`));

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,4 +1,4 @@
-const { log, spawn_log } = require("../helper");
+const { log, spawn_log, yarn } = require("../helper");
 const fs = require("fs-extra");
 const path = require("path");
 /**
@@ -55,7 +55,7 @@ module.exports = async (service, options) => {
         );
 
         log("SPA: build...");
-        await spawn_log(false, "npm", ["exec", "--", "yarn", "build"], {
+        await spawn_log(false, "npm", ["exec", "--", yarn, "build"], {
           detached: true,
           stdio: [process.stdin, log_spa, log_spa],
           cwd: path.normalize(process.cwd() + "/single-page-app"),
@@ -64,7 +64,7 @@ module.exports = async (service, options) => {
         // TODO generic solution to pass env variable to package.json script and using default
         const startScript =
           process.platform === "win32" ? "start:win" : "start";
-        spawn_log(true, "npm", ["exec", "--", "yarn", startScript], {
+        spawn_log(true, "npm", ["exec", "--", yarn, startScript], {
           detached: true,
           stdio: [process.stdin, log_spa, log_spa],
           cwd: path.normalize(process.cwd() + "/single-page-app"),
@@ -76,7 +76,7 @@ module.exports = async (service, options) => {
 
         // TODO generic solution to pass env variable to package.json script and using default
         const devScript = process.platform === "win32" ? "dev:win" : "dev";
-        spawn_log(true, "npm", ["exec", "--", "yarn", devScript], {
+        spawn_log(true, "npm", ["exec", "--", yarn, devScript], {
           detached: true,
           stdio: [process.stdin, log_spa, log_spa],
           cwd: path.normalize(process.cwd() + "/single-page-app"),
@@ -92,13 +92,13 @@ module.exports = async (service, options) => {
         await fs.remove(path.normalize(process.cwd() + "/graphiql-auth/.next"));
 
         log("GiQL: build...");
-        await spawn_log(false, "npm", ["exec", "--", "yarn", "build"], {
+        await spawn_log(false, "npm", ["exec", "--", yarn, "build"], {
           detached: true,
           stdio: [process.stdin, log_giql, log_giql],
           cwd: path.normalize(process.cwd() + "/graphiql-auth"),
         });
         log("GiQL: start...\n");
-        spawn_log(true, "npm", ["exec", "--", "yarn", "start"], {
+        spawn_log(true, "npm", ["exec", "--", yarn, "start"], {
           detached: true,
           stdio: [process.stdin, log_giql, log_giql],
           cwd: path.normalize(process.cwd() + "/graphiql-auth"),
@@ -106,7 +106,7 @@ module.exports = async (service, options) => {
       } else {
         await fs.remove(path.normalize(process.cwd() + "/graphiql-auth/.next"));
 
-        spawn_log(true, "npm", ["exec", "--", "yarn", "dev"], {
+        spawn_log(true, "npm", ["exec", "--", yarn, "dev"], {
           detached: true,
           stdio: [process.stdin, log_giql, log_giql],
           cwd: path.normalize(process.cwd() + "/graphiql-auth"),

--- a/lib/start.js
+++ b/lib/start.js
@@ -55,7 +55,7 @@ module.exports = async (service, options) => {
         );
 
         log("SPA: build...");
-        await spawn_log(false, "yarn", ["build"], {
+        await spawn_log(false, "npm", ["exec", "--", "yarn", "build"], {
           detached: true,
           stdio: [process.stdin, log_spa, log_spa],
           cwd: path.normalize(process.cwd() + "/single-page-app"),
@@ -64,7 +64,7 @@ module.exports = async (service, options) => {
         // TODO generic solution to pass env variable to package.json script and using default
         const startScript =
           process.platform === "win32" ? "start:win" : "start";
-        spawn_log(true, "yarn", [startScript], {
+        spawn_log(true, "npm", ["exec", "--", "yarn", startScript], {
           detached: true,
           stdio: [process.stdin, log_spa, log_spa],
           cwd: path.normalize(process.cwd() + "/single-page-app"),
@@ -76,7 +76,7 @@ module.exports = async (service, options) => {
 
         // TODO generic solution to pass env variable to package.json script and using default
         const devScript = process.platform === "win32" ? "dev:win" : "dev";
-        spawn_log(true, "yarn", [devScript], {
+        spawn_log(true, "npm", ["exec", "--", "yarn", devScript], {
           detached: true,
           stdio: [process.stdin, log_spa, log_spa],
           cwd: path.normalize(process.cwd() + "/single-page-app"),
@@ -92,13 +92,13 @@ module.exports = async (service, options) => {
         await fs.remove(path.normalize(process.cwd() + "/graphiql-auth/.next"));
 
         log("GiQL: build...");
-        await spawn_log(false, "yarn", ["build"], {
+        await spawn_log(false, "npm", ["exec", "--", "yarn", "build"], {
           detached: true,
           stdio: [process.stdin, log_giql, log_giql],
           cwd: path.normalize(process.cwd() + "/graphiql-auth"),
         });
         log("GiQL: start...\n");
-        spawn_log(true, "yarn", ["start"], {
+        spawn_log(true, "npm", ["exec", "--", "yarn", "start"], {
           detached: true,
           stdio: [process.stdin, log_giql, log_giql],
           cwd: path.normalize(process.cwd() + "/graphiql-auth"),
@@ -106,7 +106,7 @@ module.exports = async (service, options) => {
       } else {
         await fs.remove(path.normalize(process.cwd() + "/graphiql-auth/.next"));
 
-        spawn_log(true, "yarn", ["dev"], {
+        spawn_log(true, "npm", ["exec", "--", "yarn", "dev"], {
           detached: true,
           stdio: [process.stdin, log_giql, log_giql],
           cwd: path.normalize(process.cwd() + "/graphiql-auth"),

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ora": "^5.1.0",
     "uuid": "^8.3.2",
     "xlsx": "^0.17.5",
+    "yarn": "^1.22",
     "zendro-bulk-create": "github:Zendro-dev/zendro-bulk-create#latest-stable",
     "ZendroStarterPack": "github:Zendro-dev/ZendroStarterPack#latest-stable"
   },


### PR DESCRIPTION
I added `yarn` to the package.json and changed the `yarn` calls in new.js and stop.js to use `npm exec -- yarn` instead.
I also moved the installation commands in new.js into an own condition as @coeit proposed [here](https://github.com/Zendro-dev/zendro/issues/17#issuecomment-1557401129), so the setup of a dockerized project is way faster because the installation is done inside the containers.

This should fix issue #17 