### PR TITLE
#20 fix: stop command not working

### DIFF
--- a/lib/stop.js
+++ b/lib/stop.js
@@ -14,8 +14,33 @@ module.exports = async (service, options) => {
 
   switch (process.platform) {
     case "win32":
-        // TODO find a generic solution to only kill those node processes running the servers.
-        await spawn_console("taskkill", ["/im", "node.exe"])
+      // find PID from server-processes
+      servPrc = spawnSync("netstat", ["-aofn"]);
+      servPrc = servPrc.stdout.toString().split("\n");
+      servPrc = servPrc.filter(line => ["0:8080", "0:3000", "0:7000"].some(port => line.includes(port)) )
+                       .map(line => line.split(/ +/))
+                       .map(line => [line[2], line.pop()]);
+
+      for (let [endpoint, pid] of servPrc) {
+        switch (endpoint) {
+          case "0.0.0.0:3000":  
+            parentPID = spawnSync("wmic", ["process", "where", `(ProcessID=${pid})`, "get", "ParentProcessID"]);
+            parentPID = parentPID.stdout.toString().split(/\W+/)[1];
+            log(`stop graphql-server, PIDs: ${[parentPID, pid]}\n`);
+            await spawnSync("taskkill", ["/f", "/t", "/pid", parentPID], {stdio: "ignore"});
+            break;
+
+          case "0.0.0.0:7000":
+            log(`stop graphiQL, PIDs: ${pid}\n`);
+            await spawnSync("taskkill", ["/f", "/pid", pid], {stdio: "ignore"});
+            break;
+
+          case "0.0.0.0:8080":
+            log(`stop single-page-app, PIDs: ${pid}\n`);
+            await spawnSync("taskkill", ["/f", "/pid", pid], {stdio: "ignore"});
+            break;
+        }
+      }
       break;
   
     default:

--- a/lib/stop.js
+++ b/lib/stop.js
@@ -21,15 +21,15 @@ module.exports = async (service, options) => {
         switch (serv) {
           case "gqs":
             name = "graphql-server";
-            endpoint = "0.0.0.0:3000";
+            endpoint = / (\d+\.){3}\d+:3000 /;
             break;
           case "giql":
             name = "graphiQL";
-            endpoint = "0.0.0.0:7000";
+            endpoint = / (\d+\.){3}\d+:7000 /;
             break;
           case "spa":
             name = "single-page-app";
-            endpoint = "0.0.0.0:8080";
+            endpoint = / (\d+\.){3}\d+:8080 /;
             break;
           default:
             log(`No such service, please check your input: ${serv}\n`);
@@ -40,19 +40,19 @@ module.exports = async (service, options) => {
           // find PID from server-processes
           let servPID = spawnSync("netstat", ["-aofn"]);
           servPID = servPID.stdout.toString().split("\n");
-          servPID = servPID.filter(line => line.includes(endpoint))[0];
+          servPID = servPID.filter(line => endpoint.test(line))[0];
 
           if (servPID != undefined) {
             servPID = servPID.split(/ +/).pop();
 
             // find and stop parent process and its subprocesses
-            let parentPID = spawnSync("wmic", ["process", "where", `(ProcessID=${servPID})`, "get", "Caption,ParentProcessID"]);
-            parentPID = parentPID.stdout.toString().split(/\s+/);
-            let parentName = parentPID[2];
-            parentPID = parentPID[3];
+            let processes = spawnSync("wmic", ["process", "where", `(ProcessID=${servPID})`, "get", "Caption,ParentProcessID"]);
+            processes = processes.stdout.toString().split(/\s+/);
+            let [ parentName, parentPID ] = processes.slice(2, 4);
+
             if (parentName === "node.exe") {
               log(`stop ${name}, PIDs: ${[parentPID, servPID]}\n`);
-              await spawnSync("taskkill", ["/f", "/t", "/pid", parentPID]);
+              spawnSync("taskkill", ["/f", "/t", "/pid", parentPID]);
             }
             
           } else {

--- a/lib/stop.js
+++ b/lib/stop.js
@@ -1,4 +1,5 @@
 const { log, spawn_string, spawn_console } = require("../helper");
+const { spawnSync } = require("child_process");
 
 /**
  * Stop Zendro App.
@@ -14,31 +15,44 @@ module.exports = async (service, options) => {
 
   switch (process.platform) {
     case "win32":
-      // find PID from server-processes
-      servPrc = spawnSync("netstat", ["-aofn"]);
-      servPrc = servPrc.stdout.toString().split("\n");
-      servPrc = servPrc.filter(line => ["0:8080", "0:3000", "0:7000"].some(port => line.includes(port)) )
-                       .map(line => line.split(/ +/))
-                       .map(line => [line[2], line.pop()]);
+      for (let serv of service) {
+        let name = "";
+        let endpoint = "";
+        switch (serv) {
+          case "gqs":
+            name = "graphql-server";
+            endpoint = "0.0.0.0:3000";
+            break;
+          case "giql":
+            name = "graphiQL";
+            endpoint = "0.0.0.0:7000";
+            break;
+          case "spa":
+            name = "single-page-app";
+            endpoint = "0.0.0.0:8080";
+            break;
+          default:
+            log(`No such service, please check your input: ${serv}\n`);
+            break;
+        }
 
-      for (let [endpoint, pid] of servPrc) {
-        switch (endpoint) {
-          case "0.0.0.0:3000":  
-            parentPID = spawnSync("wmic", ["process", "where", `(ProcessID=${pid})`, "get", "ParentProcessID"]);
+        if (name) {
+          // find PID from server-processes
+          let servPID = spawnSync("netstat", ["-aofn"]);
+          servPID = servPID.stdout.toString().split("\n");
+          servPID = servPID.filter(line => line.includes(endpoint))[0];
+
+          if (servPID != undefined) {
+            servPID = servPID.split(/ +/).pop();
+
+            // find and stop parent process and its subprocesses
+            let parentPID = spawnSync("wmic", ["process", "where", `(ProcessID=${servPID})`, "get", "ParentProcessID"]);
             parentPID = parentPID.stdout.toString().split(/\W+/)[1];
-            log(`stop graphql-server, PIDs: ${[parentPID, pid]}\n`);
-            await spawnSync("taskkill", ["/f", "/t", "/pid", parentPID], {stdio: "ignore"});
-            break;
-
-          case "0.0.0.0:7000":
-            log(`stop graphiQL, PIDs: ${pid}\n`);
-            await spawnSync("taskkill", ["/f", "/pid", pid], {stdio: "ignore"});
-            break;
-
-          case "0.0.0.0:8080":
-            log(`stop single-page-app, PIDs: ${pid}\n`);
-            await spawnSync("taskkill", ["/f", "/pid", pid], {stdio: "ignore"});
-            break;
+            log(`stop ${name}, PIDs: ${[parentPID, servPID]}\n`);
+            await spawnSync("taskkill", ["/f", "/t", "/pid", parentPID]);
+          } else {
+            log(`${name} is not running, please check\n`);
+          }
         }
       }
       break;

--- a/lib/stop.js
+++ b/lib/stop.js
@@ -46,10 +46,15 @@ module.exports = async (service, options) => {
             servPID = servPID.split(/ +/).pop();
 
             // find and stop parent process and its subprocesses
-            let parentPID = spawnSync("wmic", ["process", "where", `(ProcessID=${servPID})`, "get", "ParentProcessID"]);
-            parentPID = parentPID.stdout.toString().split(/\W+/)[1];
-            log(`stop ${name}, PIDs: ${[parentPID, servPID]}\n`);
-            await spawnSync("taskkill", ["/f", "/t", "/pid", parentPID]);
+            let parentPID = spawnSync("wmic", ["process", "where", `(ProcessID=${servPID})`, "get", "Caption,ParentProcessID"]);
+            parentPID = parentPID.stdout.toString().split(/\s+/);
+            let parentName = parentPID[2];
+            parentPID = parentPID[3];
+            if (parentName === "node.exe") {
+              log(`stop ${name}, PIDs: ${[parentPID, servPID]}\n`);
+              await spawnSync("taskkill", ["/f", "/t", "/pid", parentPID]);
+            }
+            
           } else {
             log(`${name} is not running, please check\n`);
           }

--- a/lib/stop.js
+++ b/lib/stop.js
@@ -1,4 +1,4 @@
-const { log, spawn_string, spawn_console } = require("../helper");
+const { log, spawn_console } = require("../helper");
 const { spawnSync } = require("child_process");
 
 /**
@@ -33,31 +33,29 @@ module.exports = async (service, options) => {
             break;
           default:
             log(`No such service, please check your input: ${serv}\n`);
-            break;
+            continue;
         }
 
-        if (name) {
-          // find PID from server-processes
-          let servPID = spawnSync("netstat", ["-aofn"]);
-          servPID = servPID.stdout.toString().split("\n");
-          servPID = servPID.filter(line => endpoint.test(line))[0];
+        // find PID from server-processes
+        let servPID = spawnSync("netstat", ["-aofn"]);
+        servPID = servPID.stdout.toString().split("\n");
+        servPID = servPID.filter(line => endpoint.test(line))[0];
 
-          if (servPID != undefined) {
-            servPID = servPID.split(/ +/).pop();
+        if (servPID != undefined) {
+          servPID = servPID.split(/ +/).pop();
 
-            // find and stop parent process and its subprocesses
-            let processes = spawnSync("wmic", ["process", "where", `(ProcessID=${servPID})`, "get", "Caption,ParentProcessID"]);
-            processes = processes.stdout.toString().split(/\s+/);
-            let [ parentName, parentPID ] = processes.slice(2, 4);
+          // find and stop parent process and its subprocesses
+          let processes = spawnSync("wmic", ["process", "where", `(ProcessID=${servPID})`, "get", "Caption,ParentProcessID"]);
+          processes = processes.stdout.toString().split(/\s+/);
+          let [ parentName, parentPID ] = processes.slice(2, 4);
 
-            if (parentName === "node.exe") {
-              log(`stop ${name}, PIDs: ${[parentPID, servPID]}\n`);
-              spawnSync("taskkill", ["/f", "/t", "/pid", parentPID]);
-            }
-            
-          } else {
-            log(`${name} is not running, please check\n`);
+          if (parentName === "node.exe") {
+            log(`stop ${name}, PIDs: ${[parentPID, servPID]}\n`);
+            spawnSync("taskkill", ["/f", "/t", "/pid", parentPID]);
           }
+          
+        } else {
+          log(`${name} is not running, please check\n`);
         }
       }
       break;
@@ -65,37 +63,41 @@ module.exports = async (service, options) => {
     default:
       for (let serv of service) {
         let name = "";
-        let regular_exp = [];
+        let regex = null;
         // filter PID by regular expression
-        if (serv === "gqs") {
-          name = "graphql-server";
-          if (!prod) {
-            regular_exp.push(".*nodemon.*server.js");
-          }
-          regular_exp.push(".*node server.js");
-        } else if (serv == "spa") {
-          name = "single-page-app";
-          regular_exp.push(".*node.*next.*8080");
-        } else if (serv == "giql") {
-          name = "graphiQL";
-          regular_exp.push(".*node.*next.*7000");
-        } else {
-          log("No such service, please check your input:" + serv);
-          continue;
+        switch (serv) {
+          case "gqs":
+            name = "graphql-server";
+            regexStr = ".*node server.js";
+            if (!prod) {
+              regexStr += "|.*nodemon.*server.js";
+            }
+            regex = new RegExp(regexStr);
+            break;
+          case "spa":
+            name = "single-page-app";
+            regex = /.*node.*next.*8080/;
+            break;
+          case "giql":
+            name = "graphiQL";
+            regex = /.*node.*next.*7000/;
+            break;
+          default:
+            log(`No such service, please check your input: ${serv}\n`);
+            continue;
         }
-        for (let regex of regular_exp) {
-          // TODO add | grep -v grep as cmd3; spawn_string needs a new argument for that.
-          const res = await spawn_string("ps", ["-aef"], "grep", [regex], "awk", [
-            "{print $2}",
-          ]);
-          const PIDArr = res.trim().split('\n').map(pid => parseInt(pid));
-    
-          if (PIDArr.every(pid => isNaN(pid))) {
-            log(`${name} is not running, please check\n`);
-          } else {
-            log(`stop ${name}, PIDs: ${PIDArr}\n`);
-            await spawn_console("kill", ["-9", ...PIDArr]);
-          }
+        const processes = spawnSync("ps", ["-aef"]).stdout.toString();
+        let pids = processes.split("\n")
+                            .filter(line => regex.test(line))
+                            .reduce((a, line) => a.concat(line.match(/\S+/g).slice(1,3)), [])  // fetch pid and parent's pid
+                            .filter(pid => pid != 1);
+        pids = new Set(pids);
+
+        if (!pids.size) {
+          log(`${name} is not running, please check\n`);
+        } else {
+          log(`stop ${name}, PIDs: ${[...pids]}\n`);
+          await spawn_console("kill", ["-9", ...pids]);
         }
       }
   }


### PR DESCRIPTION
Changes in this PR:
 - service-specific stopping in Windows
 - reworked stopping in Linux/MacOS
 - `spawn_string` not needed anymore in `stop.js`, using `spawnSync` instead