### PR TITLE
fix: bulk-download and bulk-create working

### DIFF
--- a/lib/bulk_create.js
+++ b/lib/bulk_create.js
@@ -35,11 +35,11 @@ module.exports = async (options) => {
       const { initializeZendro } = require(process.cwd() + "/utils/zendro.js");
       const zendro = await initializeZendro();
       data_model_definition =
-        zendro.models[options.model_name.toLowerCase()].definition;
+        zendro.models.sql[options.model_name[0].toLowerCase() + options.model_name.slice(1)];
       execute_graphql = zendro.execute_graphql;
       globals = require(process.cwd() + "/config/globals");
     }
-    const file_path = path.normalize(process.cwd() + "/" + options.file_path);
+    const file_path = options.file_path;
     const file_extension = file_path.split(".").pop().toLowerCase();
 
     if (file_extension === "csv") {

--- a/lib/bulk_create.js
+++ b/lib/bulk_create.js
@@ -39,7 +39,7 @@ module.exports = async (options) => {
       execute_graphql = zendro.execute_graphql;
       globals = require(process.cwd() + "/config/globals");
     }
-    const file_path = options.file_path;
+    const file_path = path.resolve(options.file_path);
     const file_extension = file_path.split(".").pop().toLowerCase();
 
     if (file_extension === "csv") {

--- a/lib/bulk_create.js
+++ b/lib/bulk_create.js
@@ -35,7 +35,7 @@ module.exports = async (options) => {
       const { initializeZendro } = require(process.cwd() + "/utils/zendro.js");
       const zendro = await initializeZendro();
       data_model_definition =
-        zendro.models.sql[options.model_name[0].toLowerCase() + options.model_name.slice(1)];
+        zendro.models[options.model_name[0].toLowerCase() + options.model_name.slice(1)].definition;
       execute_graphql = zendro.execute_graphql;
       globals = require(process.cwd() + "/config/globals");
     }

--- a/lib/bulk_download.js
+++ b/lib/bulk_download.js
@@ -33,8 +33,7 @@ module.exports = async (options) => {
     } else {
       const { initializeZendro } = require(process.cwd() + "/utils/zendro.js");
       const zendro = await initializeZendro();
-      definition = await zendro.models[options.model_name.toLowerCase()]
-        .definition;
+      definition = await zendro.models.sql[options.model_name[0].toLowerCase() + options.model_name.slice(1)];
       execute_graphql = zendro.execute_graphql;
       globals = require(process.cwd() + "/config/globals");
     }

--- a/lib/bulk_download.js
+++ b/lib/bulk_download.js
@@ -63,7 +63,7 @@ module.exports = async (options) => {
     header = header.slice(0, -1);
 
     const file_path = options.file_path
-      ? path.normalize(process.cwd() + "/" + options.file_path)
+      ? path.resolve(options.file_path)
       : path.normalize(
           process.cwd() + "/" + options.model_name + uuidv4() + ".csv"
         );

--- a/lib/bulk_download.js
+++ b/lib/bulk_download.js
@@ -64,7 +64,7 @@ module.exports = async (options) => {
 
     const file_path = options.file_path
       ? path.resolve(options.file_path)
-      : path.normalize(
+      : path.resolve(
           process.cwd() + "/" + options.model_name + uuidv4() + ".csv"
         );
 

--- a/lib/bulk_download.js
+++ b/lib/bulk_download.js
@@ -33,7 +33,7 @@ module.exports = async (options) => {
     } else {
       const { initializeZendro } = require(process.cwd() + "/utils/zendro.js");
       const zendro = await initializeZendro();
-      definition = await zendro.models.sql[options.model_name[0].toLowerCase() + options.model_name.slice(1)];
+      definition = await zendro.models[options.model_name[0].toLowerCase() + options.model_name.slice(1)].definition;
       execute_graphql = zendro.execute_graphql;
       globals = require(process.cwd() + "/config/globals");
     }


### PR DESCRIPTION
This PR corrects some issues in code base that caused errors when trying to use `zendro bulk-download` or `zendro bulk-create` non-remotely (`-r` not set)