### PR TITLE
fix: search in spa working with default models

### DIFF
--- a/test/data_model_definitions/default/city.json
+++ b/test/data_model_definitions/default/city.json
@@ -27,5 +27,6 @@
       "keysIn": "country"	 
     }
   },
-  "internalId": "city_id"
+  "internalId": "city_id",
+  "spaSearchOperator": "like"
 }

--- a/test/data_model_definitions/default/country.json
+++ b/test/data_model_definitions/default/country.json
@@ -39,5 +39,6 @@
       "targetStorageType": "sql"
     }
   },
-  "internalId": "country_id"
+  "internalId": "country_id",
+  "spaSearchOperator": "like"
 }

--- a/test/data_model_definitions/default/river.json
+++ b/test/data_model_definitions/default/river.json
@@ -19,5 +19,6 @@
       "targetStorageType": "sql"
     }
   },
-  "internalId": "river_id"
+  "internalId": "river_id",
+  "spaSearchOperator": "like"
 }


### PR DESCRIPTION
Changes in this PR:
 - extended default model definitions by setting the search operator to `like`